### PR TITLE
Fix Hero dropdown positioning

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,16 +8,18 @@ interface HeaderProps {
   search?: string;
   onSearch?: (query: string) => void;
   results?: CompanyRow[];
-  onFocus?: () => void;   // ▼ NEW
-  active?: boolean;       // ▼ NEW
+  onFocus?: () => void;
+  active?: boolean;
 }
 
 export function Header({
   search = '',
   onSearch = noop,
   results = [],
+  onFocus = noop,
+  active = false,
 }: HeaderProps) {
-  const show = search.trim() && results.length > 0;
+  const show = active && search.trim() && results.length > 0;
 
   return (
     <header className="header">
@@ -32,7 +34,10 @@ export function Header({
         </Link>
         </div>
         {/* Search bar */}
-        <div className="site-header-search, search-container">
+        <div
+          className="site-header-search, search-container"
+          onClick={e => e.stopPropagation()}
+        >
           <svg 
             width="20px" 
             height="20px" 
@@ -50,10 +55,12 @@ export function Header({
             </clipPath>
             </defs>
           </svg>
-          <input className="input"
+          <input
+            className="input"
             type="text"
             placeholder="Rechercher un logiciel..."
             onChange={e => onSearch(e.target.value)}
+            onFocus={onFocus}
           />
 
           {/* ▾ dropdown */}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -38,12 +38,15 @@ export function Hero({
           Découvrez les meilleurs solutions logicielles françaises pour votre entreprise, organisées par catégorie. 
         </p>
         <div className="hero-search">
-            <div className="hero-search-container">
-              <svg 
-              width="20px" 
-              height="20px" 
-              viewBox="0 0 24 24" 
-              fill="none" 
+            <div
+              className="hero-search-container"
+              onClick={e => e.stopPropagation()}
+            >
+              <svg
+              width="20px"
+              height="20px"
+              viewBox="0 0 24 24"
+              fill="none"
               xmlns="http://www.w3.org/2000/svg">
               <g clip-path="url(#clip0_15_152)">
               <rect width="24" height="24" fill="white"/>
@@ -56,11 +59,20 @@ export function Hero({
               </clipPath>
               </defs>
             </svg>
-            <input className="input"
+            <input
+              className="input"
               type="text"
               placeholder="Rechercher par nom. catégorie, fonction, etc ..."
               onChange={e => onSearch(e.target.value)}
+              onFocus={onFocus}
             />
+            {show && (
+            <ul className="search-results">
+              {results.slice(0, 10).map(r => (
+                <li key={r.id}>{r.name}</li>
+              ))}
+            </ul>
+          )}
             </div>
             <button
             type="button"
@@ -71,13 +83,6 @@ export function Hero({
           >
             Rechercher
           </button>
-          {show && (
-          <ul className="search-results">
-            {results.slice(0, 10).map(r => (
-              <li key={r.id}>{r.name}</li>
-            ))}
-          </ul>
-        )}
           
         </div>
         <div className="popular-tags-container">


### PR DESCRIPTION
## Summary
- keep hero search dropdown within its search container so it positions under the hero input
- only show a dropdown when its search input has focus
- stop click events from closing the active dropdown

## Testing
- `npm install`
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_684a7f0e6914832f814b57bdd8f9a44c