### PR TITLE
Add skeleton loaders for initial data fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "papaparse": "^5.5.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-loading-skeleton": "^3.5.0",
         "react-router-dom": "^7.6.0",
         "react-scripts": "^5.0.1",
         "typescript": "^4.9.5",
@@ -13964,6 +13965,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
+    },
+    "node_modules/react-loading-skeleton": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.5.0.tgz",
+      "integrity": "sha512-gxxSyLbrEAdXTKgfbpBEFZCO/P153DnqSCQau2+o6lNy1jgMRr2MmRmOzMmyrwSaSYLRB8g7b0waYPmUjz7IhQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "papaparse": "^5.5.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-loading-skeleton": "^3.5.0",
     "react-router-dom": "^7.6.0",
     "react-scripts": "^5.0.1",
     "typescript": "^4.9.5",

--- a/src/components/CardSkeleton.tsx
+++ b/src/components/CardSkeleton.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Skeleton from 'react-loading-skeleton';
+
+export default function CardSkeleton() {
+  return (
+    <div className="card">
+      <div className="card-header">
+        <div className="company-logo">
+          <Skeleton width={80} height={80} />
+        </div>
+        <h2 className="subtitle" style={{ width: '50%' }}>
+          <Skeleton />
+        </h2>
+        <div className="visit-button" style={{ width: 60 }}>
+          <Skeleton />
+        </div>
+      </div>
+      <p className="text">
+        <Skeleton count={3} />
+      </p>
+    </div>
+  );
+}

--- a/src/components/Category.tsx
+++ b/src/components/Category.tsx
@@ -3,11 +3,12 @@ import { fetchCategories } from '../utils/api';
 import { CategoryRow } from '../types';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { slugify } from '../utils/slugify';
+import Skeleton from 'react-loading-skeleton';
 
 
 export function CategoriesSection() {
 
-  const [categories, setCategories] = useState<CategoryRow[]>([]);
+  const [categories, setCategories] = useState<CategoryRow[] | null>(null);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -15,9 +16,11 @@ export function CategoriesSection() {
   }, []);
 
   // Ensure count is treated as a number: sort descending and take top 8
-  const topCategories = [...categories]
-    .sort((a, b) => Number(b.count) - Number(a.count))
-    .slice(0, 8);
+  const topCategories = categories
+    ? [...categories]
+        .sort((a, b) => Number(b.count) - Number(a.count))
+        .slice(0, 8)
+    : Array.from({ length: 8 });
 
   return (
     <section className="categories-section">
@@ -32,26 +35,42 @@ export function CategoriesSection() {
       </div>
 
       <div className="categories-grid">
-        {topCategories.map((cat) => {
+        {topCategories.map((cat, idx) => {
+          if (!categories) {
+            return (
+              <div key={idx} className="category-card">
+                <Skeleton width={24} height={24} className="category-card__icon" />
+                <h3 className="category-card__title">
+                  <Skeleton />
+                </h3>
+                <p className="category-card__desc">
+                  <Skeleton count={2} />
+                </p>
+                <p className="category-card__count">
+                  <Skeleton width={80} />
+                </p>
+              </div>
+            );
+          }
           const truncatedDescription =
-            cat.description.length > 50
-              ? cat.description.slice(0, 50).trimEnd() + '…'
-              : cat.description;
+            cat!.description.length > 50
+              ? cat!.description.slice(0, 50).trimEnd() + '…'
+              : cat!.description;
           return (
-              <div
-                key={cat.id}
-                className="category-card"
-                onClick={() => navigate(`/categorie/${slugify(cat.name)}`)}
-              >
+            <div
+              key={cat!.id}
+              className="category-card"
+              onClick={() => navigate(`/categorie/${slugify(cat!.name)}`)}
+            >
               <img
-                src={`/icons/${cat.icon}`}
-                alt={`${cat.name} icon`}
+                src={`/icons/${cat!.icon}`}
+                alt={`${cat!.name} icon`}
                 className="category-card__icon"
               />
-              <h3 className="category-card__title">{cat.name}</h3>
+              <h3 className="category-card__title">{cat!.name}</h3>
               <p className="category-card__desc">{truncatedDescription}</p>
               <p className="category-card__count">
-                {cat.count} logiciels
+                {cat!.count} logiciels
               </p>
             </div>
           );

--- a/src/components/SelectionOfTheMonth.tsx
+++ b/src/components/SelectionOfTheMonth.tsx
@@ -3,22 +3,23 @@ import { Link, useNavigate } from 'react-router-dom';
 import { CompanyRow } from '../types';
 import { slugify } from '../utils/slugify';
 import { Cards } from './Cards';
+import CardSkeleton from './CardSkeleton';
 
 interface SelectionOfTheMonthProps {
-  /** 
-   * The full array of companies. 
-   * This component will pick out (e.g.) the first 9 for display. 
+  /**
+   * The full array of companies.
+   * This component will pick out (e.g.) the first 9 for display.
    * You can replace this logic with any “top 9” or curated list.
    */
-  companies: CompanyRow[];
+  companies: CompanyRow[] | null;
 }
 
 export const SelectionOfTheMonth: React.FC<SelectionOfTheMonthProps> = ({ companies }) => {
   const navigate = useNavigate();
 
-  
+
   // For now, just take the first 9. Adjust logic as needed.
-  const topNine = companies.slice(0, 9);
+  const topNine = companies ? companies.slice(0, 9) : Array.from({ length: 9 });
   
 const openCompanyPage = (company: CompanyRow) => {
   navigate(`/logiciel/${slugify(company.name)}`);
@@ -34,14 +35,20 @@ const openCompanyPage = (company: CompanyRow) => {
       </div>
 
       <div className="selection-grid">
-        {topNine.map(company => (
-          <div
-            key={company.id}
-            className="card-wrapper"
-            onClick={() => openCompanyPage(company)}
-          >
-            <Cards company={company} />
-          </div>
+        {topNine.map((company, idx) => (
+          companies ? (
+            <div
+              key={(company as CompanyRow).id}
+              className="card-wrapper"
+              onClick={() => openCompanyPage(company as CompanyRow)}
+            >
+              <Cards company={company as CompanyRow} />
+            </div>
+          ) : (
+            <div key={idx} className="card-wrapper">
+              <CardSkeleton />
+            </div>
+          )
         ))}
       </div>
     </section>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
+import 'react-loading-skeleton/dist/skeleton.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 

--- a/src/pages/AllCategory.tsx
+++ b/src/pages/AllCategory.tsx
@@ -5,11 +5,12 @@ import { fetchCategories } from '../utils/api';
 import { CategoryRow } from '../types';
 import { Link, useNavigate } from 'react-router-dom';
 import { slugify } from '../utils/slugify';
+import Skeleton from 'react-loading-skeleton';
 
 
 
 export default function AllCategory() {
-  const [categories, setCategories] = useState<CategoryRow[]>([]);
+  const [categories, setCategories] = useState<CategoryRow[] | null>(null);
   const navigate = useNavigate();
 
 
@@ -32,17 +33,24 @@ export default function AllCategory() {
         </nav>
         <h1 className="page-title">Toutes les catégories de logiciels français</h1>
         <div className="all-categories-grid">
-          {categories.map(category => (
-            <div
-              key={category.id}
-              className="categories-card"
-              onClick={() => navigate(`/categorie/${slugify(category.name)}`)}
-            >
-            <div className="categories-card" key={category.id}>
-              <span className="categories-name">{category.name}</span>
-              <span className="categories-count">{category.count} logiciels</span>
-            </div>
-            </div>
+          {(categories || Array.from({ length: 10 })).map((category, idx) => (
+            categories ? (
+              <div
+                key={(category as CategoryRow).id}
+                className="categories-card"
+                onClick={() => navigate(`/categorie/${slugify((category as CategoryRow).name)}`)}
+              >
+                <div className="categories-card" key={(category as CategoryRow).id}>
+                  <span className="categories-name">{(category as CategoryRow).name}</span>
+                  <span className="categories-count">{(category as CategoryRow).count} logiciels</span>
+                </div>
+              </div>
+            ) : (
+              <div key={idx} className="categories-card">
+                <span className="categories-name"><Skeleton width={120} /></span>
+                <span className="categories-count"><Skeleton width={80} /></span>
+              </div>
+            )
           ))}
         </div>
       </main>

--- a/src/pages/Category.tsx
+++ b/src/pages/Category.tsx
@@ -6,12 +6,14 @@ import { Footer } from '../components/Footer';
 import { fetchCategories, fetchCompanies } from '../utils/api';
 import { CategoryRow, CompanyRow } from '../types';
 import { Cards } from '../components/Cards';
+import CardSkeleton from '../components/CardSkeleton';
+import Skeleton from 'react-loading-skeleton';
 
 export default function Category() {
   const { slug } = useParams<{ slug: string }>();
   const navigate = useNavigate();
   const [category, setCategory] = useState<CategoryRow | null>(null);
-  const [companies, setCompanies] = useState<CompanyRow[]>([]);
+  const [companies, setCompanies] = useState<CompanyRow[] | null>(null);
 
 
   useEffect(() => {
@@ -24,7 +26,7 @@ export default function Category() {
     fetchCompanies().then(setCompanies);
   }, [slug]);
 
-  const filteredCompanies = category
+  const filteredCompanies = category && companies
     ? companies.filter(co => {
         if (!co.categories) return false;
         return co.categories
@@ -47,21 +49,32 @@ export default function Category() {
           <Link to="/toutes-categories">Toutes les catégories</Link> /{' '}
           <span>{category?.name || slug}</span>
         </nav>
-        {category && (
+        {category ? (
           <>
             <h1>{category.name}</h1>
             <p className="category-description">{category.description}</p>
           </>
+        ) : (
+          <>
+            <h1><Skeleton width={200} /></h1>
+            <p className="category-description"><Skeleton count={2} /></p>
+          </>
         )}
         <div className="selection-grid">
-          {filteredCompanies.map(company => (
-            <div
-              key={company.id}
-              className="card-wrapper"
-              onClick={() => openCompanyPage(company)}
-            >
-              <Cards company={company} />
-            </div>
+          {(companies ? filteredCompanies : Array.from({ length: 6 })).map((company, idx) => (
+            companies ? (
+              <div
+                key={(company as CompanyRow).id}
+                className="card-wrapper"
+                onClick={() => openCompanyPage(company as CompanyRow)}
+              >
+                <Cards company={company as CompanyRow} />
+              </div>
+            ) : (
+              <div key={idx} className="card-wrapper">
+                <CardSkeleton />
+              </div>
+            )
           ))}
         </div>
       </main>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,10 +9,11 @@ import MetricsBanner from '../components/MetricsBanner';
 import { useMetrics } from '../utils/useMetrics';
 import { SelectionOfTheMonth } from '../components/SelectionOfTheMonth';
 import { Footer } from '../components/Footer';
+import Skeleton from 'react-loading-skeleton';
 
 
 export default function Home() {
-  const [companies, setCompanies] = useState<CompanyRow[]>([]);
+  const [companies, setCompanies] = useState<CompanyRow[] | null>(null);
   const metrics = useMetrics();
 
 
@@ -38,7 +39,12 @@ export default function Home() {
           frenchPercentage={metrics.frenchPercentage}
         />
       ) : (
-        <p>Chargement des données</p>
+        <div style={{ display: 'flex', gap: '1rem' }}>
+          <Skeleton height={80} width={150} />
+          <Skeleton height={80} width={150} />
+          <Skeleton height={80} width={150} />
+          <Skeleton height={80} width={150} />
+        </div>
       )}
 
       <SelectionOfTheMonth companies={companies} />

--- a/src/pages/Software.tsx
+++ b/src/pages/Software.tsx
@@ -6,10 +6,11 @@ import { slugify } from '../utils/slugify';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import Company from '../components/Company';
+import Skeleton from 'react-loading-skeleton';
 
 export default function Software() {
   const { slug } = useParams<{ slug: string }>();
-  const [company, setCompany] = useState<CompanyRow | null>(null);
+  const [company, setCompany] = useState<CompanyRow | null | undefined>(undefined);
 
   useEffect(() => {
     fetchCompanies().then(data => {
@@ -20,7 +21,19 @@ export default function Software() {
     });
   }, [slug]);
 
-  if (!company) {
+  if (company === undefined) {
+    return (
+      <>
+        <Header />
+        <main className="container-category">
+          <Skeleton height={200} />
+        </main>
+        <Footer />
+      </>
+    );
+  }
+
+  if (company === null) {
     return (
       <>
         <Header />


### PR DESCRIPTION
## Summary
- add `react-loading-skeleton` dependency
- globally import skeleton CSS
- create `CardSkeleton` component for card placeholders
- show skeletons in category listings
- add skeletons for selection of the month and all categories
- show skeletons while metrics and software details load

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685796d1b728832f8f7f43cf96c382d1