### PR TITLE
Add skeleton loading states

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,7 +13,7 @@ import { Footer } from '../components/Footer';
 
 
 export default function Home() {
-  const [companies, setCompanies] = useState<CompanyRow[]>([]);
+  const [companies, setCompanies] = useState<CompanyRow[] | null>(null);
   const metrics = useMetrics();
 
 

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -7,9 +7,10 @@ import { filterCompanies } from '../utils/search';
 import { CompanyRow } from '../types';
 import { Cards } from '../components/Cards';
 import { slugify } from '../utils/slugify';
+import CardSkeleton from '../components/CardSkeleton';
 
 export default function SearchResults() {
-  const [companies, setCompanies] = useState<CompanyRow[]>([]);
+  const [companies, setCompanies] = useState<CompanyRow[] | null>(null);
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const query = searchParams.get('q') || '';
@@ -18,7 +19,7 @@ export default function SearchResults() {
     fetchCompanies().then(setCompanies);
   }, []);
 
-  const results = filterCompanies(query, companies);
+  const results = companies ? filterCompanies(query, companies) : [];
 
   const openCompanyPage = (company: CompanyRow) => {
     navigate(`/logiciel/${slugify(company.name)}`);
@@ -32,7 +33,15 @@ export default function SearchResults() {
           <Link to="/">Accueil</Link> / <span>Recherche</span>
         </nav>
         <h1>Résultats pour «{query}»</h1>
-        {results.length === 0 ? (
+        {companies === null ? (
+          <div className="selection-grid">
+            {Array.from({ length: 6 }).map((_, idx) => (
+              <div key={idx} className="card-wrapper">
+                <CardSkeleton />
+              </div>
+            ))}
+          </div>
+        ) : results.length === 0 ? (
           <p>Aucun résultat trouvé.</p>
         ) : (
           <div className="selection-grid">


### PR DESCRIPTION
## Summary
- initialize `companies` as null on the home page so skeletons display while loading
- show card skeletons on the search results page while data loads

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858531caac4832fb7f4b0b8993b1865