### PR TITLE
Add skeleton loading states

### DIFF
--- a/src/components/CompanySkeleton.tsx
+++ b/src/components/CompanySkeleton.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import Skeleton from 'react-loading-skeleton';
+
+export default function CompanySkeleton() {
+  return (
+    <div className="company">
+      <div className="company-header">
+        <div>
+          <div className="company-logo modal-logo">
+            <Skeleton width={80} height={80} />
+          </div>
+          <h2 className="company-name">
+            <Skeleton width={200} />
+          </h2>
+        </div>
+        <div className="company-buttons">
+          {Array.from({ length: 3 }).map((_, idx) => (
+            <button
+              key={idx}
+              type="button"
+              className="button modal-button"
+              style={{ width: 80 }}
+            >
+              <Skeleton />
+            </button>
+          ))}
+        </div>
+      </div>
+      <p className="company-description">
+        <Skeleton count={3} />
+      </p>
+      <div className="company-info">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <p key={idx}>
+            <Skeleton width={150} />
+          </p>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,7 +13,7 @@ import { Footer } from '../components/Footer';
 
 
 export default function Home() {
-  const [companies, setCompanies] = useState<CompanyRow[]>([]);
+  const [companies, setCompanies] = useState<CompanyRow[] | null>(null);
   const metrics = useMetrics();
 
 

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -7,9 +7,10 @@ import { filterCompanies } from '../utils/search';
 import { CompanyRow } from '../types';
 import { Cards } from '../components/Cards';
 import { slugify } from '../utils/slugify';
+import CardSkeleton from '../components/CardSkeleton';
 
 export default function SearchResults() {
-  const [companies, setCompanies] = useState<CompanyRow[]>([]);
+  const [companies, setCompanies] = useState<CompanyRow[] | null>(null);
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const query = searchParams.get('q') || '';
@@ -18,7 +19,7 @@ export default function SearchResults() {
     fetchCompanies().then(setCompanies);
   }, []);
 
-  const results = filterCompanies(query, companies);
+  const results = companies ? filterCompanies(query, companies) : [];
 
   const openCompanyPage = (company: CompanyRow) => {
     navigate(`/logiciel/${slugify(company.name)}`);
@@ -32,7 +33,15 @@ export default function SearchResults() {
           <Link to="/">Accueil</Link> / <span>Recherche</span>
         </nav>
         <h1>Résultats pour «{query}»</h1>
-        {results.length === 0 ? (
+        {companies === null ? (
+          <div className="selection-grid">
+            {Array.from({ length: 6 }).map((_, idx) => (
+              <div key={idx} className="card-wrapper">
+                <CardSkeleton />
+              </div>
+            ))}
+          </div>
+        ) : results.length === 0 ? (
           <p>Aucun résultat trouvé.</p>
         ) : (
           <div className="selection-grid">

--- a/src/pages/Software.tsx
+++ b/src/pages/Software.tsx
@@ -6,10 +6,11 @@ import { slugify } from '../utils/slugify';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import Company from '../components/Company';
+import CompanySkeleton from '../components/CompanySkeleton';
 
 export default function Software() {
   const { slug } = useParams<{ slug: string }>();
-  const [company, setCompany] = useState<CompanyRow | null>(null);
+  const [company, setCompany] = useState<CompanyRow | null | undefined>(undefined);
 
   useEffect(() => {
     fetchCompanies().then(data => {
@@ -20,7 +21,19 @@ export default function Software() {
     });
   }, [slug]);
 
-  if (!company) {
+  if (company === undefined) {
+    return (
+      <>
+        <Header />
+        <main className="container-category">
+          <CompanySkeleton />
+        </main>
+        <Footer />
+      </>
+    );
+  }
+
+  if (company === null) {
     return (
       <>
         <Header />


### PR DESCRIPTION
## Summary
- initialize `companies` as `null` on the home page so skeletons display while loading
- show card skeletons on the search results page while data loads
- add `CompanySkeleton` and use it on the company page

## Testing
- `npm test --silent` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6858531caac4832fb7f4b0b8993b1865