### PR TITLE
Disable Clarity tracking on localhost

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,18 +5,22 @@
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-G80ZMPRCM1"></script>
     <!-- Clarity tracking code for https://logicielfrance.com/ -->
     <script>
-        (function(c,l,a,r,i,t,y){
-            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";
-            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+      if (["localhost", "127.0.0.1"].indexOf(window.location.hostname) === -1) {
+        (function(c, l, a, r, i, t, y) {
+          c[a] = c[a] || function() { (c[a].q = c[a].q || []).push(arguments); };
+          t = l.createElement(r); t.async = 1; t.src = "https://www.clarity.ms/tag/" + i + "?ref=bwt";
+          y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
         })(window, document, "clarity", "script", "s1g27sjeuv");
+      }
     </script>
     <script type="text/javascript">
-      (function(c,l,a,r,i,t,y){
-          c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-          t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-          y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-      })(window, document, "clarity", "script", "s1g3t2mxdm");
+      if (["localhost", "127.0.0.1"].indexOf(window.location.hostname) === -1) {
+        (function(c, l, a, r, i, t, y) {
+          c[a] = c[a] || function() { (c[a].q = c[a].q || []).push(arguments); };
+          t = l.createElement(r); t.async = 1; t.src = "https://www.clarity.ms/tag/" + i;
+          y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
+        })(window, document, "clarity", "script", "s1g3t2mxdm");
+      }
     </script>
       
     <script>


### PR DESCRIPTION
## Summary
- avoid loading Microsoft Clarity scripts when running on localhost

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68585725b7fc832fb75d43a56712714b