### PR TITLE
Improve header responsiveness

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,6 +10,7 @@ export function Header() {
   const [companies, setCompanies] = useState<CompanyRow[]>([]);
   const [search, setSearch] = useState('');
   const [active, setActive] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -19,6 +20,7 @@ export function Header() {
     useEffect(() => {
     function handleClickAway() {
       setActive(false);
+      setSearchOpen(false);
     }
     document.addEventListener('click', handleClickAway);
     return () => document.removeEventListener('click', handleClickAway);
@@ -40,69 +42,78 @@ export function Header() {
           />
         </Link>
         </div>
-        {/* Search bar */}
+        {/* Search icon */}
         <div
-          className="site-header-search, search-container"
-          onClick={e => e.stopPropagation()}
+          className="search-icon"
+          onClick={e => {
+            e.stopPropagation();
+            setSearchOpen(true);
+          }}
         >
-          <svg 
-            width="20px" 
-            height="20px" 
-            viewBox="0 0 24 24" 
-            fill="none" 
-            xmlns="http://www.w3.org/2000/svg">
-            <g clip-path="url(#clip0_15_152)">
-            <rect width="24" height="24" fill="white"/>
-            <circle cx="10.5" cy="10.5" r="6.5" stroke="#000000" stroke-linejoin="round"/>
-            <path d="M19.6464 20.3536C19.8417 20.5488 20.1583 20.5488 20.3536 20.3536C20.5488 20.1583 20.5488 19.8417 20.3536 19.6464L19.6464 20.3536ZM20.3536 19.6464L15.3536 14.6464L14.6464 15.3536L19.6464 20.3536L20.3536 19.6464Z" fill="#000000"/>
+          <svg
+            width="20px"
+            height="20px"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g clip-path="url(#clip0_header)">
+              <rect width="24" height="24" fill="white" />
+              <circle cx="10.5" cy="10.5" r="6.5" stroke="#000000" stroke-linejoin="round" />
+              <path d="M19.6464 20.3536C19.8417 20.5488 20.1583 20.5488 20.3536 20.3536C20.5488 20.1583 20.5488 19.8417 20.3536 19.6464L19.6464 20.3536ZM20.3536 19.6464L15.3536 14.6464L14.6464 15.3536L19.6464 20.3536L20.3536 19.6464Z" fill="#000000" />
             </g>
             <defs>
-            <clipPath id="clip0_15_152">
-            <rect width="24" height="24" fill="none"/>
-            </clipPath>
+              <clipPath id="clip0_header">
+                <rect width="24" height="24" fill="none" />
+              </clipPath>
             </defs>
           </svg>
-          <input
-            className="input"
-            type="text"
-            placeholder="Rechercher un logiciel..."
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-            onFocus={() => setActive(true)}
-            onKeyDown={e => {
-              if (e.key === 'Enter') {
-                navigate(`/recherche?q=${encodeURIComponent(search)}`);
-              }
-            }}
-          />
-
-          {/* ▾ dropdown */}
-          {show && (
-            <div className="search-wrapper">
-              <ul className="search-results">
-                {results.slice(0, 10).map(row => (
-                  <li key={row.id} className="result-item">
-                    <Link to={`/logiciel/${slugify(row.name)}`}>
-                      <strong className="result-item-text">{row.name}</strong>
-                    </Link>
-                  </li>
-                ))}
-                {results.length > 10 && (
-                  <li className="result-more">…{results.length - 10} autres résultats</li>
-                )}
-              </ul>
-            </div>
-          )}
         </div>
         
         {/* CTA */}
         <Link to="/ajouter-un-nouveau-logiciel">
-
-          <button className="button" >
-            Ajouter votre logiciel
+          <button className="button add-button" aria-label="Ajouter un logiciel">
+            +
           </button>
         </Link>
       </div>
+      {searchOpen && (
+        <div className="search-overlay" onClick={() => setSearchOpen(false)}>
+          <div className="search-container" onClick={e => e.stopPropagation()}>
+            <input
+              className="input"
+              type="text"
+              placeholder="Rechercher un logiciel..."
+              value={search}
+              autoFocus
+              onChange={e => setSearch(e.target.value)}
+              onFocus={() => setActive(true)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  navigate(`/recherche?q=${encodeURIComponent(search)}`);
+                  setSearchOpen(false);
+                }
+              }}
+            />
+            {show && (
+              <div className="search-wrapper">
+                <ul className="search-results">
+                  {results.slice(0, 10).map(row => (
+                    <li key={row.id} className="result-item">
+                      <Link to={`/logiciel/${slugify(row.name)}`}> 
+                        <strong className="result-item-text">{row.name}</strong>
+                      </Link>
+                    </li>
+                  ))}
+                  {results.length > 10 && (
+                    <li className="result-more">…{results.length - 10} autres résultats</li>
+                  )}
+                </ul>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </header>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -352,6 +352,36 @@ max-width: 80px;
   border: 0.5px solid #4E4E4E;
   border-radius: 5px;
 }
+.search-icon {
+  cursor: pointer;
+  padding: 0.4rem;
+  border: 1px solid #4E4E4E;
+  border-radius: 5px;
+}
+
+.search-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 3000;
+}
+
+.search-overlay .search-container {
+  width: 80%;
+  max-width: 500px;
+  padding: 0.4rem 1rem;
+}
+
+.add-button {
+  padding: 0.4rem 0.8rem;
+  font-size: 20px;
+}
 
 .input {
   outline: none;


### PR DESCRIPTION
## Summary
- collapse search box behind a search icon
- show search box overlay when clicking icon
- shrink "add software" button to a plus icon
- style overlay and icons

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685859f5b168832f908c1a7016ec7425