### PR TITLE
Implement mobile header design

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,7 +10,14 @@ export function Header() {
   const [companies, setCompanies] = useState<CompanyRow[]>([]);
   const [search, setSearch] = useState('');
   const [active, setActive] = useState(false);
+  const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
   const navigate = useNavigate();
+
+  const handleSearchIconClick = () => {
+    if (window.innerWidth <= 768) {
+      setMobileSearchOpen(true);
+    }
+  };
 
   useEffect(() => {
     fetchCompanies().then(data => setCompanies(data));
@@ -45,12 +52,14 @@ export function Header() {
           className="site-header-search, search-container"
           onClick={e => e.stopPropagation()}
         >
-          <svg 
-            width="20px" 
-            height="20px" 
-            viewBox="0 0 24 24" 
-            fill="none" 
-            xmlns="http://www.w3.org/2000/svg">
+          <svg
+            width="20px"
+            height="20px"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            onClick={handleSearchIconClick}
+          >
             <g clip-path="url(#clip0_15_152)">
             <rect width="24" height="24" fill="white"/>
             <circle cx="10.5" cy="10.5" r="6.5" stroke="#000000" stroke-linejoin="round"/>
@@ -97,12 +106,38 @@ export function Header() {
         
         {/* CTA */}
         <Link to="/ajouter-un-nouveau-logiciel">
-
-          <button className="button" >
-            Ajouter votre logiciel
+          <button className="button add-button" >
+            <span className="add-text">Ajouter votre logiciel</span>
+            <span className="add-icon">+</span>
           </button>
         </Link>
       </div>
+      {mobileSearchOpen && (
+        <div
+          className="mobile-search-overlay"
+          onClick={() => setMobileSearchOpen(false)}
+        >
+          <div
+            className="mobile-search-container"
+            onClick={e => e.stopPropagation()}
+          >
+            <input
+              autoFocus
+              className="input"
+              type="text"
+              placeholder="Rechercher un logiciel..."
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  navigate(`/recherche?q=${encodeURIComponent(search)}`);
+                  setMobileSearchOpen(false);
+                }
+              }}
+            />
+          </div>
+        </div>
+      )}
     </header>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1077,3 +1077,53 @@ selection-card {
   from { transform: rotate(0deg); }
   to   { transform: rotate(360deg); }
 }
+
+/* Hide mobile-only icons by default */
+.add-button .add-icon {
+  display: none;
+}
+
+/* Mobile header adjustments */
+@media (max-width: 768px) {
+  .search-container {
+    width: auto;
+    padding: 0;
+    border: none;
+  }
+  .search-container .input {
+    display: none;
+  }
+  .add-button .add-text {
+    display: none;
+  }
+  .add-button .add-icon {
+    display: block;
+    font-size: 24px;
+    line-height: 1;
+    color: #fff;
+  }
+}
+
+.mobile-search-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(5px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 3000;
+}
+
+.mobile-search-container {
+  width: 80%;
+  display: flex;
+  align-items: center;
+  background: #fff;
+  padding: 0.4rem 1rem;
+  border: 0.5px solid #4E4E4E;
+  border-radius: 5px;
+}


### PR DESCRIPTION
## Summary
- show icon-only search on small screens and open a center overlay when clicked
- hide text for "add software" button on phones and show a `+` icon
- style overlay and responsive header in CSS
- ensure the `+` icon only appears on mobile

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6858d3caae3c832f89e5ee9442ec2abd