### PR TITLE
Add legal pages and footer links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,9 @@ import AddSoftware from './pages/AddSoftware';
 import AllCategory from './pages/AllCategory';
 import Category from './pages/Category';
 import SearchResults from './pages/SearchResults';
+import MentionsLegales from './pages/MentionsLegales';
+import PolitiqueConfidentialite from './pages/PolitiqueConfidentialite';
+import ConditionsUtilisation from './pages/ConditionsUtilisation';
 import LLMInjection from './components/LLMInjection';
 
 
@@ -28,6 +31,15 @@ export default function App() {
         <Route path="/categorie/:slug" element={<Category />} />
         <Route path="/logiciel/:slug" element={<Software />} />
         <Route path="/recherche" element={<SearchResults />} />
+        <Route path="/mentions-legales" element={<MentionsLegales />} />
+        <Route
+          path="/politique-de-confidentialite"
+          element={<PolitiqueConfidentialite />}
+        />
+        <Route
+          path="/conditions-utilisation"
+          element={<ConditionsUtilisation />}
+        />
         {/* …other routes */}
       </Routes>
     </Router>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,7 +6,11 @@ import React from 'react';
 export function Footer() {
   const categories = ['Finance', 'Marketing', 'Vente', 'Contenu', 'Logistique'];
   const resources  = ['À propos', 'Blog', 'Contact'];
-  const legal      = ['Mentions légales', 'Politique de confidentialité', 'Conditions d\'utilisation'];
+  const legal      = [
+    { label: 'Mentions légales', path: '/mentions-legales' },
+    { label: 'Politique de confidentialité', path: '/politique-de-confidentialite' },
+    { label: "Conditions d'utilisation", path: '/conditions-utilisation' }
+  ];
   const currentYear = new Date().getFullYear();
 
   return (
@@ -49,7 +53,9 @@ export function Footer() {
           <h4>Légal</h4>
           <ul>
             {legal.map(item => (
-              <li key={item} className="link">{item}</li>
+              <li key={item.path} className="link">
+                <Link to={item.path}>{item.label}</Link>
+              </li>
             ))}
           </ul>
         </div>

--- a/src/pages/ConditionsUtilisation.tsx
+++ b/src/pages/ConditionsUtilisation.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Header } from '../components/Header';
+import { Footer } from '../components/Footer';
+
+export default function ConditionsUtilisation() {
+  return (
+    <>
+      <Header />
+      <main className="container mx-auto p-6">
+        <h1>Conditions d'utilisation</h1>
+        <section>
+          <h2>Objet</h2>
+          <p>
+            Les présentes conditions régissent l'utilisation du site et des
+            services proposés. En accédant au site, vous acceptez sans réserve
+            ces conditions.
+          </p>
+        </section>
+        <section>
+          <h2>Accès au service</h2>
+          <p>
+            Le site est accessible gratuitement. Nous nous réservons toutefois
+            le droit de suspendre l'accès pour maintenance ou en cas de force
+            majeure.
+          </p>
+        </section>
+        <section>
+          <h2>Propriété intellectuelle</h2>
+          <p>
+            Tout le contenu du site est protégé par le droit de la propriété
+            intellectuelle. Toute reproduction ou représentation totale ou
+            partielle est interdite sans autorisation préalable.
+          </p>
+        </section>
+        <section>
+          <h2>Modification des conditions</h2>
+          <p>
+            Nous pouvons modifier les présentes conditions à tout moment. Les
+            utilisateurs seront informés de toute mise à jour par la simple mise
+            en ligne des nouvelles conditions.
+          </p>
+        </section>
+        <section>
+          <h2>Droit applicable</h2>
+          <p>
+            Les présentes conditions sont soumises au droit français. En cas de
+            litige, les tribunaux français seront seuls compétents.
+          </p>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/pages/MentionsLegales.tsx
+++ b/src/pages/MentionsLegales.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Header } from '../components/Header';
+import { Footer } from '../components/Footer';
+
+export default function MentionsLegales() {
+  return (
+    <>
+      <Header />
+      <main className="container mx-auto p-6">
+        <h1>Mentions légales</h1>
+        <section>
+          <h2>Éditeur du site</h2>
+          <p>
+            Ce site est édité par <strong>[Nom de l&apos;éditeur]</strong>.
+            Pour toute question, vous pouvez nous contacter à l&apos;adresse
+            <a href="mailto:contact@example.com"> contact@example.com</a>.
+          </p>
+        </section>
+        <section>
+          <h2>Hébergement</h2>
+          <p>
+            Le site est hébergé par <strong>[Nom de l&apos;hébergeur]</strong>,
+            dont le siège social est situé à <strong>[Adresse]</strong>.
+          </p>
+        </section>
+        <section>
+          <h2>Propriété intellectuelle</h2>
+          <p>
+            L&apos;ensemble des contenus présents sur ce site (textes, images,
+            logos, etc.) est protégé par le droit d&apos;auteur. Toute
+            reproduction, même partielle, est interdite sans autorisation
+            préalable.
+          </p>
+        </section>
+        <section>
+          <h2>Responsabilité</h2>
+          <p>
+            Les informations fournies sur ce site sont indicatives. Nous
+            mettons tout en œuvre pour assurer leur exactitude mais ne
+            saurions être tenus responsables en cas d&apos;erreur ou
+            d&apos;omission.
+          </p>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/pages/PolitiqueConfidentialite.tsx
+++ b/src/pages/PolitiqueConfidentialite.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Header } from '../components/Header';
+import { Footer } from '../components/Footer';
+
+export default function PolitiqueConfidentialite() {
+  return (
+    <>
+      <Header />
+      <main className="container mx-auto p-6">
+        <h1>Politique de confidentialité</h1>
+        <section>
+          <h2>Données collectées</h2>
+          <p>
+            Nous collectons uniquement les données nécessaires au bon
+            fonctionnement du service. Aucune donnée personnelle n'est cédée à
+            des tiers sans votre consentement.
+          </p>
+        </section>
+        <section>
+          <h2>Utilisation des données</h2>
+          <p>
+            Les informations recueillies sont utilisées pour améliorer le
+            service et répondre à vos demandes. Vous pouvez à tout moment
+            demander l'accès, la rectification ou la suppression de vos
+            données.
+          </p>
+        </section>
+        <section>
+          <h2>Cookies</h2>
+          <p>
+            Ce site peut utiliser des cookies afin d'analyser la fréquentation
+            ou de proposer des fonctionnalités de partage sur les réseaux
+            sociaux. Vous pouvez désactiver les cookies dans les préférences de
+            votre navigateur.
+          </p>
+        </section>
+        <section>
+          <h2>Contact</h2>
+          <p>
+            Pour exercer vos droits ou pour toute question relative à la
+            protection de vos données, contactez-nous à
+            <a href="mailto:contact@example.com"> contact@example.com</a>.
+          </p>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add Mentions légales, Politique de confidentialité and Conditions d'utilisation pages
- add routes for legal pages in `App.tsx`
- update footer to link to the new legal pages

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685bc0b8e77c832f9623aa1075e9843b