### PR TITLE
Add informational pages and footer links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import SearchResults from './pages/SearchResults';
 import MentionsLegales from './pages/MentionsLegales';
 import PolitiqueConfidentialite from './pages/PolitiqueConfidentialite';
 import ConditionsUtilisation from './pages/ConditionsUtilisation';
+import APropos from './pages/APropos';
+import Contact from './pages/Contact';
 import LLMInjection from './components/LLMInjection';
 
 
@@ -31,6 +33,8 @@ export default function App() {
         <Route path="/categorie/:slug" element={<Category />} />
         <Route path="/logiciel/:slug" element={<Software />} />
         <Route path="/recherche" element={<SearchResults />} />
+        <Route path="/a-propos" element={<APropos />} />
+        <Route path="/contact" element={<Contact />} />
         <Route path="/mentions-legales" element={<MentionsLegales />} />
         <Route
           path="/politique-de-confidentialite"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,7 +5,11 @@ import React from 'react';
 
 export function Footer() {
   const categories = ['Finance', 'Marketing', 'Vente', 'Contenu', 'Logistique'];
-  const resources  = ['À propos', 'Blog', 'Contact'];
+  const resources = [
+    { label: 'À propos', path: '/a-propos' },
+    { label: 'Blog', path: '/blog' },
+    { label: 'Contact', path: '/contact' }
+  ];
   const legal      = [
     { label: 'Mentions légales', path: '/mentions-legales' },
     { label: 'Politique de confidentialité', path: '/politique-de-confidentialite' },
@@ -42,8 +46,10 @@ export function Footer() {
         <div>
           <h4>Ressources</h4>
           <ul>
-            {resources.map(res => (
-              <li key={res} className="link">{res}</li>
+            {resources.map(item => (
+              <li key={item.path} className="link">
+                <Link to={item.path}>{item.label}</Link>
+              </li>
             ))}
           </ul>
         </div>

--- a/src/pages/APropos.tsx
+++ b/src/pages/APropos.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Header } from '../components/Header';
+import { Footer } from '../components/Footer';
+
+export default function APropos() {
+  return (
+    <>
+      <Header />
+      <main className="container mx-auto p-6">
+        <h1>À propos de Logiciel France</h1>
+        <section className="legal-section">
+          <p>
+            Logiciel France a pour mission de promouvoir les logiciels et entreprises technologiques
+            made in France. Nous rassemblons dans un annuaire unique les solutions conçues
+            sur le territoire afin de faciliter la mise en relation entre éditeurs et utilisateurs.
+          </p>
+          <p>
+            Le projet est né d\'une volonté de mettre en avant le savoir‑faire
+            français et de favoriser l\'écosystème local. Toutes les données
+            présentées proviennent d\'une feuille Google Sheets ouverte à la
+            communauté et mise à jour régulièrement.
+          </p>
+          <p>
+            N\'hésitez pas à nous contacter si vous souhaitez référencer votre logiciel
+            ou contribuer à l\'amélioration du site.
+          </p>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Header } from '../components/Header';
+import { Footer } from '../components/Footer';
+
+export default function Contact() {
+  return (
+    <>
+      <Header />
+      <main className="container mx-auto p-6">
+        <h1>Contact</h1>
+        <section className="legal-section">
+          <p>
+            Une question, une suggestion ou l\'envie de référencer votre logiciel&nbsp;?
+            Écrivez‑nous à&nbsp;
+            <a href="mailto:logiciel@logicielfrance.com">logiciel@logicielfrance.com</a>
+            &nbsp;et nous reviendrons vers vous rapidement.
+          </p>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create APropos page
- create Contact page
- link the pages from the footer
- register new routes in the router

## Testing
- `npm test --silent -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bebeed114832fa6a078197d974155