### PR TITLE
Add mobile friendly scrolling and category layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -532,6 +532,21 @@ max-width: 80px;
   margin: 0 auto;
 }
 
+@media (max-width: 768px) {
+  .categories-grid {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem;
+  }
+  .categories-grid::-webkit-scrollbar {
+    display: none;
+  }
+  .category-card {
+    flex: 0 0 auto;
+  }
+}
+
 /* Individual card */
 .category-card {
   background: #fff;
@@ -623,6 +638,23 @@ max-width: 80px;
   grid-template-columns: repeat(3, 1fr);
   gap: .5rem;             /* Space between cards */
 
+}
+
+@media (max-width: 768px) {
+  .selection-grid {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    gap: .5rem;
+    padding-bottom: 1rem;
+  }
+  .selection-grid::-webkit-scrollbar {
+    display: none;
+  }
+  .selection-grid .card-wrapper {
+    flex: 0 0 auto;
+  }
 }
 
 selection-card {
@@ -873,6 +905,15 @@ selection-card {
   max-width: 1200px;
   margin: 60px auto;
   padding: 1rem;
+}
+
+.category-page .selection-grid {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+}
+.category-page .card-wrapper {
+  width: 100%;
 }
 
 .all-categories-grid {

--- a/src/pages/Category.tsx
+++ b/src/pages/Category.tsx
@@ -43,7 +43,7 @@ export default function Category() {
   return (
     <>
       <Header />
-      <main className="container-category">
+      <main className="container-category category-page">
         <nav className="breadcrumbs">
           <Link to="/">Accueil</Link> /{' '}
           <Link to="/toutes-categories">Toutes les catégories</Link> /{' '}


### PR DESCRIPTION
## Summary
- enable horizontal scrolling for categories and selection of the month
- show category page results stacked vertically

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6861bd2b98d8832f82c3bee3e15a7e48