### PR TITLE
Fix scroll position on mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import APropos from './pages/APropos';
 import Contact from './pages/Contact';
 import LLMInjection from './components/LLMInjection';
 import Canonical from './components/Canonical';
+import ScrollToTop from './components/ScrollToTop';
 
 
 
@@ -33,6 +34,7 @@ export default function App({ location }: AppProps) {
     <Router {...routerProps}>
       <Canonical />
       <LLMInjection isLLMBot={isLLMBot} />
+      <ScrollToTop />
       <Routes>
         <Route path="/" element={<Home />} />
         <Route

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a `ScrollToTop` component
- use it in `App` so that each route change resets scroll position

## Testing
- `npm test` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666b5e93cc832fab83085c753f0459