### PR TITLE
Add meta description tag for software pages

### DIFF
--- a/src/pages/Software.tsx
+++ b/src/pages/Software.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
 import { useParams, Link } from 'react-router-dom';
 import { fetchCompanies } from '../utils/api';
 import { CompanyRow } from '../types';
@@ -51,6 +52,11 @@ export default function Software() {
 
   return (
     <>
+      <Helmet>
+        {company.meta_description && (
+          <meta name="description" content={company.meta_description} />
+        )}
+      </Helmet>
       <Header />
       <main className="container-category">
         <nav className="breadcrumbs">

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface CompanyRow {
   asset_1: string;
   asset_2: string;
   asset_3: string;
+  meta_description?: string;
 }
 
 export interface CategoryRow {


### PR DESCRIPTION
## Summary
- support `meta_description` field in `CompanyRow`
- output meta description tag for each software page

## Testing
- `npm install --legacy-peer-deps --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6866749da8b0832fa312a374d251369d