### PR TITLE
Use `<Link>` components for navigation

### DIFF
--- a/src/components/Category.tsx
+++ b/src/components/Category.tsx
@@ -1,14 +1,13 @@
 import React, { useEffect, useState } from 'react'
 import { fetchCategories } from '../utils/api';
 import { CategoryRow } from '../types';
-import { NavLink, useNavigate } from 'react-router-dom';
+import { NavLink, Link } from 'react-router-dom';
 import { slugify } from '../utils/slugify';
 
 
 export function CategoriesSection() {
 
   const [categories, setCategories] = useState<CategoryRow[]>([]);
-  const navigate = useNavigate();
 
   useEffect(() => {
     fetchCategories().then((cats) => setCategories(cats));
@@ -38,10 +37,10 @@ export function CategoriesSection() {
               ? cat.description.slice(0, 50).trimEnd() + '…'
               : cat.description;
           return (
-              <div
+              <Link
                 key={cat.id}
                 className="category-card"
-                onClick={() => navigate(`/categorie/${slugify(cat.name)}`)}
+                to={`/categorie/${slugify(cat.name)}`}
               >
               <img
                 src={`/icons/${cat.icon}`}
@@ -56,7 +55,7 @@ export function CategoriesSection() {
               <p className="category-card__count">
                 {cat.count} logiciels
               </p>
-            </div>
+            </Link>
           );
         })}
       </div>

--- a/src/components/SelectionOfTheMonth.tsx
+++ b/src/components/SelectionOfTheMonth.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { CompanyRow } from '../types';
 import { slugify } from '../utils/slugify';
 import { Cards } from './Cards';
@@ -15,7 +15,6 @@ interface SelectionOfTheMonthProps {
 }
 
 export const SelectionOfTheMonth: React.FC<SelectionOfTheMonthProps> = ({ companies }) => {
-  const navigate = useNavigate();
 
   const monthName = new Date().toLocaleString('fr-FR', { month: 'long' });
 
@@ -24,9 +23,6 @@ export const SelectionOfTheMonth: React.FC<SelectionOfTheMonthProps> = ({ compan
     : Array.from({ length: 9 }, () => null);
 
 
-const openCompanyPage = (company: CompanyRow) => {
-  navigate(`/logiciel/${slugify(company.name)}`);
-};
 
   return (
     <section className="selection-month">
@@ -45,15 +41,13 @@ const openCompanyPage = (company: CompanyRow) => {
       <div className="selection-grid">
         {topNine.map((company, idx) => (
            company ? (
-            <div
+            <Link
               key={company.id}
               className="card-wrapper"
-              onClick={() => openCompanyPage(company)}
-              role="button"
-              tabIndex={0}
+              to={`/logiciel/${slugify(company.name)}`}
             >
               <Cards company={company} />
-            </div>
+            </Link>
           ) : (
             <div key={idx} className="card-wrapper">
               <CardSkeleton />

--- a/src/pages/AllCategory.tsx
+++ b/src/pages/AllCategory.tsx
@@ -4,14 +4,13 @@ import { Footer } from '../components/Footer';
 import { fetchCategories } from '../utils/api';
 import { CategoryRow } from '../types';
 import Skeleton from 'react-loading-skeleton';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { slugify } from '../utils/slugify';
 
 
 
 export default function AllCategory() {
   const [categories, setCategories] = useState<CategoryRow[] | null>(null);
-  const navigate = useNavigate();
 
 
   useEffect(() => {
@@ -35,16 +34,14 @@ export default function AllCategory() {
         <div className="all-categories-grid">
           {(categories || Array.from({ length: 10 })).map((category, idx) => (
             categories ? (
-              <div
+              <Link
                 key={(category as CategoryRow).id}
                 className="categories-card"
-                onClick={() => navigate(`/categorie/${slugify((category as CategoryRow).name)}`)}
+                to={`/categorie/${slugify((category as CategoryRow).name)}`}
               >
-                <div className="categories-card" key={(category as CategoryRow).id}>
-                  <span className="categories-name">{(category as CategoryRow).name}</span>
-                  <span className="categories-count">{(category as CategoryRow).count} logiciels</span>
-                </div>
-              </div>
+                <span className="categories-name">{(category as CategoryRow).name}</span>
+                <span className="categories-count">{(category as CategoryRow).count} logiciels</span>
+              </Link>
             ) : (
               <div key={idx} className="categories-card">
                 <span className="categories-name"><Skeleton width={120} /></span>

--- a/src/pages/AllSoftwares.tsx
+++ b/src/pages/AllSoftwares.tsx
@@ -5,12 +5,11 @@ import { fetchCompanies } from '../utils/api';
 import { CompanyRow } from '../types';
 import { Cards } from '../components/Cards';
 import { slugify } from '../utils/slugify';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import CardSkeleton from '../components/CardSkeleton';
 
 export default function AllSoftwares() {
   const [companies, setCompanies] = useState<CompanyRow[] | null>(null);
-  const navigate = useNavigate();
 
   useEffect(() => {
     fetchCompanies().then(data => {
@@ -21,9 +20,6 @@ export default function AllSoftwares() {
     });
   }, []);
 
-  const openCompanyPage = (company: CompanyRow) => {
-    navigate(`/logiciel/${slugify(company.name)}`);
-  };
 
   return (
     <>
@@ -38,15 +34,13 @@ export default function AllSoftwares() {
         <div className="selection-grid">
           {(companies || Array.from({ length: 9 })).map((company, idx) => (
             companies ? (
-              <div
+              <Link
                 key={(company as CompanyRow).id}
                 className="card-wrapper"
-                onClick={() => openCompanyPage(company as CompanyRow)}
-                role="button"
-                tabIndex={0}
+                to={`/logiciel/${slugify((company as CompanyRow).name)}`}
               >
                 <Cards company={company as CompanyRow} />
-              </div>
+              </Link>
             ) : (
               <div key={idx} className="card-wrapper">
                 <CardSkeleton />

--- a/src/pages/Category.tsx
+++ b/src/pages/Category.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { slugify } from '../utils/slugify';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
@@ -11,7 +11,6 @@ import Skeleton from 'react-loading-skeleton';
 
 export default function Category() {
   const { slug } = useParams<{ slug: string }>();
-  const navigate = useNavigate();
   const [category, setCategory] = useState<CategoryRow | null>(null);
   const [companies, setCompanies] = useState<CompanyRow[] | null>(null);
 
@@ -36,9 +35,6 @@ export default function Category() {
       })
     : [];
 
-  const openCompanyPage = (company: CompanyRow) => {
-    navigate(`/logiciel/${slugify(company.name)}`);
-  };
 
   return (
     <>
@@ -66,15 +62,13 @@ export default function Category() {
         <div className="selection-grid">
           {(companies ? filteredCompanies : Array.from({ length: 6 })).map((company, idx) => (
             companies ? (
-              <div
+              <Link
                 key={(company as CompanyRow).id}
                 className="card-wrapper"
-                onClick={() => openCompanyPage(company as CompanyRow)}
-                role="button"
-                tabIndex={0}
+                to={`/logiciel/${slugify((company as CompanyRow).name)}`}
               >
                 <Cards company={company as CompanyRow} />
-              </div>
+              </Link>
             ) : (
               <div key={idx} className="card-wrapper">
                 <CardSkeleton />

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useSearchParams, Link } from 'react-router-dom';
+import { useSearchParams, Link } from 'react-router-dom';
 import { Header } from '../components/Header';
 import { Footer } from '../components/Footer';
 import { fetchCompanies } from '../utils/api';
@@ -12,7 +12,6 @@ import CardSkeleton from '../components/CardSkeleton';
 export default function SearchResults() {
   const [companies, setCompanies] = useState<CompanyRow[] | null>(null);
   const [searchParams] = useSearchParams();
-  const navigate = useNavigate();
   const query = searchParams.get('q') || '';
 
   useEffect(() => {
@@ -21,9 +20,6 @@ export default function SearchResults() {
 
   const results = companies ? filterCompanies(query, companies) : [];
 
-  const openCompanyPage = (company: CompanyRow) => {
-    navigate(`/logiciel/${slugify(company.name)}`);
-  };
 
   return (
     <>
@@ -46,15 +42,13 @@ export default function SearchResults() {
         ) : (
           <div className="selection-grid">
             {results.map(company => (
-              <div
+              <Link
                 key={company.id}
                 className="card-wrapper"
-                onClick={() => openCompanyPage(company)}
-                role="button"
-                tabIndex={0}
+                to={`/logiciel/${slugify(company.name)}`}
               >
                 <Cards company={company} highlight={query} />
-              </div>
+              </Link>
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary
- swap JS navigation for `<Link>` elements
- update category cards to link directly to routes
- remove unused `useNavigate` helpers

## Testing
- `npm test --silent -- --watchAll=false`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686784497da0832fb6fd0b5c37bee4dd