### PR TITLE
Add alphabet navigation component

### DIFF
--- a/src/components/AlphabetNav.tsx
+++ b/src/components/AlphabetNav.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { CompanyRow } from '../types';
+
+interface AlphabetNavProps {
+  companies: CompanyRow[];
+}
+
+export default function AlphabetNav({ companies }: AlphabetNavProps) {
+  const letters = Array.from(
+    new Set(companies.map(c => c.name.charAt(0).toUpperCase()))
+  ).sort();
+
+  const [start, setStart] = useState(0);
+
+  const visible = letters.slice(start, start + 10);
+
+  const showArrows = letters.length > 10;
+
+  return (
+    <div className="alphabet-nav">
+      {showArrows && (
+        <button
+          className="alphabet-arrow"
+          onClick={() => setStart(Math.max(0, start - 10))}
+          disabled={start === 0}
+        >
+          {'<'}
+        </button>
+      )}
+      {visible.map(letter => (
+        <a key={letter} href={`#letter-${letter}`} className="alphabet-letter">
+          {letter}
+        </a>
+      ))}
+      {showArrows && (
+        <button
+          className="alphabet-arrow"
+          onClick={() =>
+            setStart(
+              Math.min(start + 10, Math.max(letters.length - 10, 0))
+            )
+          }
+          disabled={start + 10 >= letters.length}
+        >
+          {'>'}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1265,6 +1265,36 @@ selection-card {
   border-radius: 5px;
 }
 
+.alphabet-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.alphabet-letter {
+  color: #000091;
+  text-decoration: none;
+  padding: 0.25rem 0.5rem;
+  font-weight: 500;
+}
+
+.alphabet-letter:hover {
+  text-decoration: underline;
+}
+
+.alphabet-arrow {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.alphabet-arrow:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 /* breakpoints.css */
 @media (max-width: 768px) {
   /* Styles pour cellphone */

--- a/src/pages/AllSoftwares.tsx
+++ b/src/pages/AllSoftwares.tsx
@@ -7,6 +7,7 @@ import { Cards } from '../components/Cards';
 import { slugify } from '../utils/slugify';
 import { Link } from 'react-router-dom';
 import CardSkeleton from '../components/CardSkeleton';
+import AlphabetNav from '../components/AlphabetNav';
 
 export default function AllSoftwares() {
   const [companies, setCompanies] = useState<CompanyRow[] | null>(null);
@@ -31,6 +32,7 @@ export default function AllSoftwares() {
         <h1>Tous les logiciels</h1>
         <p>Retrouvez la liste exhaustive de tout les logiciels français disponible.</p>
         <p>La liste est mise à jour quotidiennement.</p>
+        {companies && <AlphabetNav companies={companies} />}
         <div className="selection-grid software-list-grid">
           {(companies || Array.from({ length: 9 })).map((company, idx) => (
             companies ? (
@@ -38,6 +40,17 @@ export default function AllSoftwares() {
                 key={(company as CompanyRow).id}
                 className="card-wrapper"
                 to={`/logiciel/${slugify((company as CompanyRow).name)}`}
+                id={(() => {
+                  const letter = (company as CompanyRow).name
+                    .charAt(0)
+                    .toUpperCase();
+                  const prev = idx > 0
+                    ? (companies as CompanyRow[])[idx - 1].name
+                        .charAt(0)
+                        .toUpperCase()
+                    : '';
+                  return letter !== prev ? `letter-${letter}` : undefined;
+                })()}
               >
                 <Cards company={company as CompanyRow} />
               </Link>


### PR DESCRIPTION
## Summary
- create `AlphabetNav` for alphabet-based selection
- use `AlphabetNav` in All Softwares page and mark first card of each letter
- add styling for alphabet navigation

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6869868dbf00832f8860eff1a93c8fef