### PR TITLE
Implement server-side data fetching

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,9 +21,10 @@ import ScrollToTop from './components/ScrollToTop';
 
 interface AppProps {
   location?: string;
+  initialData?: any;
 }
 
-export default function App({ location }: AppProps) {
+export default function App({ location, initialData }: AppProps) {
 
    const isLLMBot = true;
    const Router: any = location ? StaticRouter : BrowserRouter;
@@ -49,8 +50,19 @@ export default function App({ location }: AppProps) {
           element={<AddSoftware />}
         />
         <Route path="/toutes-categories" element={<AllCategory />} />
-        <Route path="/categorie/:slug" element={<Category />} />
-        <Route path="/logiciel/:slug" element={<Software />} />
+        <Route
+          path="/categorie/:slug"
+          element={
+            <Category
+              initialCategory={initialData?.category}
+              initialCompanies={initialData?.companies}
+            />
+          }
+        />
+        <Route
+          path="/logiciel/:slug"
+          element={<Software initialCompany={initialData?.company} />}
+        />
         <Route path="/tous-les-logiciels" element={<AllSoftwares />} />
         <Route path="/recherche" element={<SearchResults />} />
         <Route path="/a-propos" element={<APropos />} />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,10 +8,12 @@ import { HelmetProvider } from 'react-helmet-async';
 
 const container = document.getElementById('root') as HTMLElement;
 
+const initialData = (window as any).__INITIAL_DATA__;
+
 const AppTree = (
   <React.StrictMode>
     <HelmetProvider>
-      <App />
+      <App initialData={initialData} />
     </HelmetProvider>
   </React.StrictMode>
 );

--- a/src/pages/Category.tsx
+++ b/src/pages/Category.tsx
@@ -9,21 +9,30 @@ import { Cards } from '../components/Cards';
 import CardSkeleton from '../components/CardSkeleton';
 import Skeleton from 'react-loading-skeleton';
 
-export default function Category() {
+interface CategoryProps {
+  initialCategory?: CategoryRow | null;
+  initialCompanies?: CompanyRow[] | null;
+}
+
+export default function Category({ initialCategory, initialCompanies }: CategoryProps) {
   const { slug } = useParams<{ slug: string }>();
-  const [category, setCategory] = useState<CategoryRow | null>(null);
-  const [companies, setCompanies] = useState<CompanyRow[] | null>(null);
+  const [category, setCategory] = useState<CategoryRow | null>(initialCategory ?? null);
+  const [companies, setCompanies] = useState<CompanyRow[] | null>(initialCompanies ?? null);
 
 
   useEffect(() => {
-    fetchCategories().then(cats => {
-      const found = cats.find(
-        c => c.id === slug || slugify(c.name) === slug
-      );
-      setCategory(found || null);
-    });
-    fetchCompanies().then(setCompanies);
-  }, [slug]);
+    if (!initialCategory || (initialCategory && initialCategory.id !== slug && slugify(initialCategory.name) !== slug)) {
+      fetchCategories().then(cats => {
+        const found = cats.find(
+          c => c.id === slug || slugify(c.name) === slug
+        );
+        setCategory(found || null);
+      });
+    }
+    if (!initialCompanies) {
+      fetchCompanies().then(setCompanies);
+    }
+  }, [slug, initialCategory, initialCompanies]);
 
   const filteredCompanies = category && companies
     ? companies.filter(co => {
@@ -81,3 +90,4 @@ export default function Category() {
     </>
   );
 }
+

--- a/src/pages/Software.tsx
+++ b/src/pages/Software.tsx
@@ -9,18 +9,32 @@ import { Footer } from '../components/Footer';
 import Company from '../components/Company';
 import CompanySkeleton from '../components/CompanySkeleton';
 
-export default function Software() {
+interface SoftwareProps {
+  initialCompany?: CompanyRow | null;
+}
+
+export default function Software({ initialCompany }: SoftwareProps) {
   const { slug } = useParams<{ slug: string }>();
-  const [company, setCompany] = useState<CompanyRow | null | undefined>(undefined);
+  const [company, setCompany] = useState<CompanyRow | null | undefined>(
+    initialCompany === undefined ? undefined : initialCompany
+  );
 
   useEffect(() => {
-    fetchCompanies().then(data => {
-      const found = data.find(
-        c => slugify(c.name) === slug || c.id === slug
-      );
-      setCompany(found || null);
-    });
-  }, [slug]);
+    if (
+      !initialCompany ||
+      (initialCompany &&
+        slug &&
+        slugify(initialCompany.name) !== slug &&
+        initialCompany.id !== slug)
+    ) {
+      fetchCompanies().then(data => {
+        const found = data.find(
+          c => slugify(c.name) === slug || c.id === slug
+        );
+        setCompany(found || null);
+      });
+    }
+  }, [slug, initialCompany]);
 
   if (company === undefined) {
     return (
@@ -74,3 +88,4 @@ export default function Software() {
     </>
   );
 }
+


### PR DESCRIPTION
## Summary
- pre-load company and category data in `server.js`
- expose fetched data through `window.__INITIAL_DATA__`
- hydrate app with initial data in `index.tsx`
- pass data to routes in `App.tsx`
- allow `Software` and `Category` pages to use provided data

## Testing
- `CI=true npm test --silent`
- `npm run build` *(fails to fetch remote data during build)*

------
https://chatgpt.com/codex/tasks/task_e_686c27efbc30832f82855d342c61c24f