### PR TITLE
Add <noscript> fallback for meta descriptions

### DIFF
--- a/src/pages/Software.tsx
+++ b/src/pages/Software.tsx
@@ -71,6 +71,9 @@ export default function Software({ initialCompany }: SoftwareProps) {
           <meta name="description" content={company.meta_description} />
         )}
       </Helmet>
+      {company.meta_description && (
+        <noscript>{company.meta_description}</noscript>
+      )}
       <Header />
       <main className="container-category">
         <nav className="breadcrumbs">


### PR DESCRIPTION
## Summary
- add noscript output on software pages so crawlers without JS can read descriptions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c3008f6f4832fa29d74ecbfafde53