### PR TITLE
Fix SSR missing env vars

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+require('dotenv').config();
 const path = require('path');
 const express = require('express');
 const React = require('react');


### PR DESCRIPTION
## Summary
- load `.env` variables in the Node server

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d796b6204832f87313e02cbbc9bcd