### PR TITLE
Polyfill fetch for Node scripts and server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "^16.18.126",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
+        "node-fetch": "^2.7.0",
         "papaparse": "^5.5.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -12176,6 +12177,48 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-forge": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^16.18.126",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
+    "node-fetch": "^2.7.0",
     "papaparse": "^5.5.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/scripts/build-blog.js
+++ b/scripts/build-blog.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 require('dotenv').config();
+const fetch = require('node-fetch');
 
 // Configuration Notion
 const NOTION_API_URL = 'https://api.notion.com/v1';

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const Papa = require('papaparse');
 const path = require('path');
 require('dotenv').config();
+const fetch = require('node-fetch');
 
 const TODAY = new Date().toISOString().split('T')[0];
 

--- a/scripts/indexnow.js
+++ b/scripts/indexnow.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const fetch = require('node-fetch');
 
 const HOST = 'www.logicielfrance.com';
 const KEY = '82fe11e68c9c40bb9a4c55579a849434';

--- a/server.js
+++ b/server.js
@@ -4,6 +4,14 @@ const path = require('path');
 const express = require('express');
 const React = require('react');
 const ReactDOMServer = require('react-dom/server');
+// Polyfill fetch in Node environments where it's not available
+if (typeof fetch === 'undefined') {
+  const fetchImpl = require('node-fetch');
+  global.fetch = fetchImpl;
+  global.Headers = fetchImpl.Headers;
+  global.Request = fetchImpl.Request;
+  global.Response = fetchImpl.Response;
+}
 const tsNode = require('ts-node');
 tsNode.register({
   transpileOnly: true,


### PR DESCRIPTION
## Summary
- add `node-fetch` to dependencies
- polyfill `fetch` globally for Node server
- import `node-fetch` in build and sitemap scripts for server-side data fetching

## Testing
- `npm test -- --watchAll=false`
- `npm run build` *(fails: ENETUNREACH when fetching external resources)*

------
https://chatgpt.com/codex/tasks/task_e_68adb02809c8832faf69ddff039eb130